### PR TITLE
[DEMO] Delete assignment/location

### DIFF
--- a/src/components/admin/AdminCard.tsx
+++ b/src/components/admin/AdminCard.tsx
@@ -12,13 +12,14 @@ import {
   Input,
   EditableInput,
 } from '@chakra-ui/react';
-import { CheckIcon, CloseIcon, EditIcon } from '@chakra-ui/icons';
+import { CheckIcon, CloseIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import { Assignment, Location } from '@prisma/client';
 import { UseTRPCMutationResult } from '@trpc/react/shared';
 
 interface AdminCardProps {
   assignmentOrLocation: Assignment | Location;
   editMutation: UseTRPCMutationResult<any, any, any, any>;
+  handleDelete: (id: number) => Promise<void>;
 }
 
 const EditableControls = () => {
@@ -40,7 +41,7 @@ const EditableControls = () => {
  * Component which represents a single assignment or location
  */
 const AdminCard = (props: AdminCardProps) => {
-  const { assignmentOrLocation, editMutation } = props;
+  const { assignmentOrLocation, editMutation, handleDelete } = props;
   const boxColor = useColorModeValue('gray.100', 'gray.700');
   const [isChecked, setIsChecked] = useState(assignmentOrLocation.active);
 
@@ -73,6 +74,7 @@ const AdminCard = (props: AdminCardProps) => {
           Active?
         </Text>
         <Switch onChange={handleActiveChange} mt={2.5} ml={3} isChecked={isChecked} />
+		<DeleteIcon ml={5} mt={2} onClick={() => handleDelete(assignmentOrLocation.id)} />
       </Flex>
     </>
   );

--- a/src/components/admin/AdminView.tsx
+++ b/src/components/admin/AdminView.tsx
@@ -24,6 +24,8 @@ const AdminView = () => {
   const createLocationMutation = trpc.admin.createLocation.useMutation();
   const editLocationMutation = trpc.admin.editLocation.useMutation();
   const setSiteSettingsMutation = trpc.admin.setSiteSettings.useMutation();
+  const deleteAssignmentMutation = trpc.admin.deleteAssignment.useMutation();
+  const deleteLocationMutation = trpc.admin.deleteLocation.useMutation();
 
   useEffect(() => {
     if (siteSettings) {
@@ -55,6 +57,17 @@ const AdminView = () => {
     const data = await createLocationMutation.mutateAsync({ name: locationText });
     setLocations(prev => [...prev!, data]);
   };
+
+  const handleDeleteAssignment = async (id: number) => {
+	await deleteAssignmentMutation.mutateAsync({ id });
+	// We can also just invalidate the query, but this makes the UI feel more responsive
+	setAssignments(prev => prev!.filter(assignment => assignment.id !== id)); 
+  }
+
+  const handleDeleteLocation = async (id: number) => {
+	await deleteLocationMutation.mutateAsync({ id });
+	setLocations(prev => prev!.filter(location => location.id !== id));
+  }
 
   // Sets the pending stage to enabled or disabled depending on the current state
   const handleTogglePendingStageEnabled = async () => {
@@ -91,7 +104,7 @@ const AdminView = () => {
         </Flex>
       </Flex>
       {assignments.map(assignment => (
-        <AdminCard key={assignment.id} assignmentOrLocation={assignment} editMutation={editAssignmentMutation} />
+        <AdminCard key={assignment.id} assignmentOrLocation={assignment} editMutation={editAssignmentMutation} handleDelete={handleDeleteAssignment} />
       ))}
 
       <Flex direction='column' w='50%' mt={10} mb={3}>
@@ -106,7 +119,7 @@ const AdminView = () => {
         </Flex>
       </Flex>
       {locations.map(location => (
-        <AdminCard key={location.id} assignmentOrLocation={location} editMutation={editLocationMutation} />
+        <AdminCard key={location.id} assignmentOrLocation={location} editMutation={editLocationMutation} handleDelete={handleDeleteLocation} />
       ))}
 
       <Flex direction='column' mt={10} mb={3}>

--- a/src/server/trpc/router/admin.ts
+++ b/src/server/trpc/router/admin.ts
@@ -68,6 +68,34 @@ export const adminRouter = router({
       });
     }),
 
+  deleteLocation: protectedStaffProcedure
+    .input(
+	  z.object({
+		id: z.number(),
+	  }),
+	)
+	.mutation(async ({ input, ctx }) => {
+	  return ctx.prisma.location.delete({
+		where: {
+		  id: input.id,
+		},
+	  });
+	}),
+	 
+  deleteAssignment: protectedStaffProcedure
+    .input(
+	  z.object({
+		id: z.number(),
+	  }),
+	)
+	.mutation(async ({ input, ctx }) => {
+	  return ctx.prisma.assignment.delete({
+		where: {
+		  id: input.id,
+		},
+	  });
+	}),
+
   setSiteSettings: protectedStaffProcedure
     .input(
       z.object({


### PR DESCRIPTION
# DO NOT MERGE THIS. IT WILL RUIN THE DATABASE

This is only for demo purposes to show how someone might go about implementing a feature like this. Look at the files for comments about each change. 

The intention is to have a delete icon on each location/assignment in the admin panel. When you press it, it should delete the assignment from the databases:
![image](https://user-images.githubusercontent.com/24885081/199863095-fec04243-6719-4d3e-8d70-7b974d5e31f6.png)

We can't actually have this because tickets are required to have an assignment/location associated with them, so deleting a location/assignment would break the schema. However since we don't want all of them to be visible, https://github.com/Berkeley-CS61B/simple-office-hours-queue/issues/26 allows for hiding assignments and locations.