### PR TITLE
Handle all fix

### DIFF
--- a/src/components/modals/HandleAllConfirmationModal.tsx
+++ b/src/components/modals/HandleAllConfirmationModal.tsx
@@ -1,0 +1,43 @@
+import {
+	ModalFooter,
+	Modal,
+	ModalContent,
+	ModalHeader,
+	ModalBody,
+	ModalCloseButton,
+	Button,
+	useColorModeValue,
+  } from '@chakra-ui/react';
+  import { DARK_GRAY_COLOR } from '../../utils/constants';
+  
+  interface HandleAllConfirmationModalProps {
+	isModalOpen: boolean;
+	setIsModalOpen: (isOpen: boolean) => void;
+	handleConfirm: () => void;
+	handleAllText: string;
+  }
+  
+  const HandleAllConfirmationModal = (props: HandleAllConfirmationModalProps) => {
+	const { isModalOpen, setIsModalOpen, handleConfirm, handleAllText } = props;
+  
+	return (
+	  <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+		<ModalContent backgroundColor={useColorModeValue('', DARK_GRAY_COLOR)}>
+		  <ModalHeader>Confirm</ModalHeader>
+		  <ModalCloseButton />
+		  <ModalBody>Are you sure you want to {handleAllText} tickets? </ModalBody>
+		  <ModalFooter>
+			<Button variant='ghost' mr={3} onClick={() => setIsModalOpen(false)}>
+			  Cancel
+			</Button>
+			<Button colorScheme='blue' onClick={handleConfirm}>
+			  Confirm
+			</Button>
+		  </ModalFooter>
+		</ModalContent>
+	  </Modal>
+	);
+  };
+  
+  export default HandleAllConfirmationModal;
+  

--- a/src/components/ticket-page/InnerTicketInfo.tsx
+++ b/src/components/ticket-page/InnerTicketInfo.tsx
@@ -87,7 +87,7 @@ const InnerTicketInfo = (props: InnerTicketInfoProps) => {
 	  'ticket-marked-as-priority'
     ];
 
-    const shouldNotNotifyStudent: string[] = ['ticket-staffnote', 'tickets-marked-as-priority'];
+    const shouldNotNotifyStudent: string[] = ['ticket-staffnote', 'ticket-marked-as-priority'];
 
     if (shouldUpdateTicketMessages.includes(message)) {
       context.ticket.getTicket.invalidate({ id: ticket.id });

--- a/src/server/trpc/router/ticket.ts
+++ b/src/server/trpc/router/ticket.ts
@@ -12,6 +12,7 @@ import {
 } from '@prisma/client';
 import { router, protectedProcedure, protectedStaffProcedure, protectedNotStudentProcedure } from '../trpc';
 import { z } from 'zod';
+import { TRPCClientError } from '@trpc/client';
 
 export const ticketRouter = router({
   createTicket: protectedProcedure
@@ -42,7 +43,7 @@ export const ticketRouter = router({
       });
 
       if (doesStudentHaveActiveTicket) {
-        return;
+        // return;
       }
 
       const pendingStageEnabled = await ctx.prisma.settings.findUnique({
@@ -113,12 +114,13 @@ export const ticketRouter = router({
 
       const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
       const channel = ably.channels.get('tickets');
-      await channel.publish('new-ticket', ticketWithNames[0]);
+      await channel.publish('new-ticket', undefined);
 
-      if (isPriority && ticket.personalQueueId === null) {
-        const staffChannel = ably.channels.get('staff-broadcast');
-        await staffChannel.publish('tickets-marked-as-priority', 'There is a new priority ticket');
-      }
+      /***** Removing staff broadcast for now *****/
+      //   if (isPriority && ticket.personalQueueId === null) {
+      //     const staffChannel = ably.channels.get('staff-broadcast');
+      //     await staffChannel.publish('tickets-marked-as-priority', 'There is a new priority ticket');
+      //   }
 
       return ticketWithNames[0];
     }),
@@ -130,28 +132,20 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const approvedTickets: Ticket[] = [];
-
-      for (const ticketId of input.ticketIds) {
-        const ticket: Ticket = await ctx.prisma.ticket.update({
-          where: { id: ticketId },
-          data: { status: TicketStatus.OPEN },
-        });
-        approvedTickets.push(ticket);
-      }
-
-      await convertTicketToTicketWithNames(approvedTickets, ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-approved', tickets);
-
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-approved', ticket);
-        }
-        return tickets;
+      await ctx.prisma.ticket.updateMany({
+        where: { id: { in: input.ticketIds } },
+        data: { status: TicketStatus.OPEN },
       });
+
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-approved', undefined);
+
+      // Use inner ticket channel
+      for (const id of input.ticketIds) {
+        const channel = ably.channels.get(`ticket-${id}`);
+        await channel.publish('ticket-approved', undefined);
+      }
     }),
 
   assignTickets: protectedNotStudentProcedure
@@ -161,10 +155,9 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const assignedTickets: Ticket[] = [];
-
       for (const ticketId of input.ticketIds) {
-        const ticket: Ticket = await ctx.prisma.ticket.update({
+        // updateMany is not working here, so we have to use update
+        await ctx.prisma.ticket.update({
           where: { id: ticketId },
           data: {
             status: TicketStatus.ASSIGNED,
@@ -176,21 +169,17 @@ export const ticketRouter = router({
             },
           },
         });
-        assignedTickets.push(ticket);
       }
 
-      await convertTicketToTicketWithNames(assignedTickets, ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-assigned', tickets);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-assigned', undefined);
 
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-assigned', ticket);
-        }
-        return tickets;
-      });
+      // Uses ticket inner page channel
+      for (const id of input.ticketIds) {
+        const channel = ably.channels.get(`ticket-${id}`);
+        await channel.publish('ticket-assigned', undefined);
+      }
     }),
 
   resolveTickets: protectedNotStudentProcedure
@@ -200,28 +189,20 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const resolvedTickets: Ticket[] = [];
-
-      for (const ticketId of input.ticketIds) {
-        const ticket: Ticket = await ctx.prisma.ticket.update({
-          where: { id: ticketId },
-          data: { status: TicketStatus.RESOLVED, resolvedAt: new Date() },
-        });
-        resolvedTickets.push(ticket);
-      }
-
-      await convertTicketToTicketWithNames(resolvedTickets, ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-resolved', tickets);
-
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-resolved', ticket);
-        }
-        return tickets;
+      await ctx.prisma.ticket.updateMany({
+        where: { id: { in: input.ticketIds } },
+        data: { status: TicketStatus.RESOLVED, resolvedAt: new Date() },
       });
+
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-resolved', undefined);
+
+      // Uses ticket inner page channel
+      for (const id of input.ticketIds) {
+        const channel = ably.channels.get(`ticket-${id}`);
+        await channel.publish('ticket-resolved', undefined);
+      }
     }),
 
   markAsAbsent: protectedProcedure
@@ -232,23 +213,18 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const ticket: Ticket = await ctx.prisma.ticket.update({
+      await ctx.prisma.ticket.update({
         where: { id: input.ticketId },
         data: { status: input.markOrUnmark ? TicketStatus.ABSENT : TicketStatus.OPEN, markedAbsentAt: new Date() },
       });
 
-      await convertTicketToTicketWithNames([ticket], ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-marked-as-absent', tickets);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-marked-as-absent', undefined);
 
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-marked-as-absent', ticket);
-        }
-        return tickets;
-      });
+      // Uses ticket inner page channel
+      const innerChannel = ably.channels.get(`ticket-${input.ticketId}`);
+      await innerChannel.publish('ticket-marked-as-absent', undefined);
     }),
 
   markAsPriority: protectedNotStudentProcedure
@@ -259,30 +235,26 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const ticket: Ticket = await ctx.prisma.ticket.update({
+      await ctx.prisma.ticket.update({
         where: { id: input.ticketId },
         data: { isPriority: input.isPriority },
       });
 
-      await convertTicketToTicketWithNames([ticket], ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-marked-as-priority', tickets);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-marked-as-priority', undefined);
 
-        for (const ticket of tickets) {
-          const ticketChannel = ably.channels.get(`ticket-${ticket.id}`);
-          await ticketChannel.publish('ticket-marked-as-priority', ticket);
-        }
+      const ticketChannel = ably.channels.get(`ticket-${input.ticketId}`);
+      await ticketChannel.publish('ticket-marked-as-priority', undefined);
 
-        if (input.isPriority && ticket.personalQueueId === null) {
-          const staffChannel = ably.channels.get('staff-broadcast');
-          await staffChannel.publish('tickets-marked-as-priority', 'There is a new priority ticket');
-        }
-        return tickets;
-      });
+      /***** Removing staff broadcast for now *****/
+
+      //   if (input.isPriority && ticket.personalQueueId === null) {
+      //       const staffChannel = ably.channels.get('staff-broadcast');
+      //       await staffChannel.publish('tickets-marked-as-priority', 'There is a new priority ticket');
+      //   }
     }),
 
-  // We only allow the creator of the ticket to close it
   closeTicket: protectedProcedure
     .input(
       z.object({
@@ -295,26 +267,24 @@ export const ticketRouter = router({
           id: input.ticketId,
         },
       });
+
+      // We only allow the creator of the ticket to close it
       if (ticket?.createdByUserId !== ctx.session?.user?.id && ctx.session?.user?.role !== UserRole.STAFF) {
-        throw new Error('You are not authorized to close this ticket');
+        throw new TRPCClientError('You are not authorized to close this ticket');
       }
 
-      const closedTicket: Ticket = await ctx.prisma.ticket.update({
+      await ctx.prisma.ticket.update({
         where: { id: input.ticketId },
         data: { status: TicketStatus.CLOSED },
       });
 
-      await convertTicketToTicketWithNames([closedTicket], ctx).then(async ticketsWithNames => {
-        const ticketWithName: TicketWithNames = ticketsWithNames[0]!;
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('ticket-closed', ticketWithName);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('ticket-closed', undefined);
 
-        // Uses ticket inner page channel
-        const innerChannel = ably.channels.get(`ticket-${ticket?.id}`);
-        await innerChannel.publish('ticket-closed', ticketWithName);
-        return ticketWithName;
-      });
+      // Uses ticket inner page channel
+      const innerChannel = ably.channels.get(`ticket-${input.ticketId}`);
+      await innerChannel.publish('ticket-closed', undefined);
     }),
 
   requeueTickets: protectedNotStudentProcedure
@@ -324,28 +294,22 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const requeuedTickets: Ticket[] = [];
-
       for (const ticketId of input.ticketIds) {
-        const ticket: Ticket = await ctx.prisma.ticket.update({
+        await ctx.prisma.ticket.update({
           where: { id: ticketId },
           data: { status: TicketStatus.OPEN },
         });
-        requeuedTickets.push(ticket);
       }
 
-      await convertTicketToTicketWithNames(requeuedTickets, ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-requeued', tickets);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-requeued', undefined);
 
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-requeued', ticket);
-        }
-        return tickets;
-      });
+      // Uses ticket inner page channel
+      for (const id of input.ticketIds) {
+        const channel = ably.channels.get(`ticket-${id}`);
+        await channel.publish('ticket-requeued', undefined);
+      }
     }),
 
   reopenTickets: protectedNotStudentProcedure
@@ -355,28 +319,20 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const reopenedTickets: Ticket[] = [];
-
-      for (const ticketId of input.ticketIds) {
-        const ticket: Ticket = await ctx.prisma.ticket.update({
-          where: { id: ticketId },
-          data: { status: TicketStatus.OPEN },
-        });
-        reopenedTickets.push(ticket);
-      }
-
-      await convertTicketToTicketWithNames(reopenedTickets, ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('tickets-reopened', tickets);
-
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-reopened', ticket);
-        }
-        return tickets;
+      await ctx.prisma.ticket.updateMany({
+        where: { id: { in: input.ticketIds } },
+        data: { status: TicketStatus.OPEN },
       });
+
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('tickets-reopened', undefined);
+
+      // Uses ticket inner page channel
+      for (const id of input.ticketIds) {
+        const channel = ably.channels.get(`ticket-${id}`);
+        await channel.publish('ticket-reopened', undefined);
+      }
     }),
 
   joinTicketGroup: protectedProcedure
@@ -386,7 +342,7 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const ticket: Ticket = await ctx.prisma.ticket.update({
+      await ctx.prisma.ticket.update({
         where: { id: input.ticketId },
         data: {
           usersInGroup: {
@@ -408,17 +364,13 @@ export const ticketRouter = router({
         },
       });
 
-      await convertTicketToTicketWithNames([ticket], ctx).then(async ticketsWithNames => {
-        const ticketWithName: TicketWithNames = ticketsWithNames[0]!;
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('ticket-joined', ticketWithName);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('ticket-joined', undefined);
 
-        // Uses ticket inner page channel
-        const innerChannel = ably.channels.get(`ticket-${ticket.id}`);
-        await innerChannel.publish('ticket-joined', ticketWithName);
-        return ticketWithName;
-      });
+      // Uses ticket inner page channel
+      const innerChannel = ably.channels.get(`ticket-${input.ticketId}`);
+      await innerChannel.publish('ticket-joined', undefined);
     }),
 
   leaveTicketGroup: protectedProcedure
@@ -428,7 +380,7 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const ticket: Ticket = await ctx.prisma.ticket.update({
+      await ctx.prisma.ticket.update({
         where: { id: input.ticketId },
         data: {
           usersInGroup: {
@@ -450,17 +402,13 @@ export const ticketRouter = router({
         },
       });
 
-      await convertTicketToTicketWithNames([ticket], ctx).then(async ticketsWithNames => {
-        const ticketWithName: TicketWithNames = ticketsWithNames[0]!;
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('ticket-left', ticketWithName);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('ticket-left', undefined);
 
-        // Uses ticket inner page channel
-        const innerChannel = ably.channels.get(`ticket-${ticket.id}`);
-        await innerChannel.publish('ticket-left', ticketWithName);
-        return ticketWithName;
-      });
+      // Uses ticket inner page channel
+      const innerChannel = ably.channels.get(`ticket-${input.ticketId}`);
+      await innerChannel.publish('ticket-left', undefined);
     }),
 
   sendChatMessage: protectedProcedure
@@ -513,9 +461,8 @@ export const ticketRouter = router({
     )
     .mutation(async ({ input, ctx }) => {
       // Closes all open, pending, and assigned tickets.
-      // Note: This is slower than using updateMany but it allows us to push to Ably
-      const closedTickets: Ticket[] = [];
 
+      // Get tickets for pushing to Ably
       const tickets = await ctx.prisma.ticket.findMany({
         where: {
           status: {
@@ -525,25 +472,28 @@ export const ticketRouter = router({
         },
       });
 
-      for (const ticket of tickets) {
-        const closedTicket: Ticket = await ctx.prisma.ticket.update({
-          where: { id: ticket.id },
-          data: { status: TicketStatus.CLOSED },
-        });
-        closedTickets.push(closedTicket);
-      }
-
-      await convertTicketToTicketWithNames(closedTickets, ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
-        const channel = ably.channels.get('tickets');
-        await channel.publish('all-tickets-closed', tickets);
-
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-closed', ticket);
-        }
-        return tickets;
+      // Close tickets
+      await ctx.prisma.ticket.updateMany({
+        where: {
+          status: {
+            in: [TicketStatus.OPEN, TicketStatus.PENDING, TicketStatus.ASSIGNED, TicketStatus.ABSENT],
+          },
+          ...(input.personalQueueName ? { personalQueueName: input.personalQueueName } : { personalQueueName: null }),
+        },
+        data: {
+          status: TicketStatus.CLOSED,
+        },
       });
+
+      // Push to Ably
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const channel = ably.channels.get('tickets');
+      await channel.publish('all-tickets-closed', undefined);
+
+      for (const ticket of tickets) {
+        const channel = ably.channels.get(`ticket-${ticket.id}`);
+        await channel.publish('ticket-closed', undefined);
+      }
     }),
 
   setStaffNotes: protectedNotStudentProcedure
@@ -554,21 +504,16 @@ export const ticketRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const ticket = await ctx.prisma.ticket.update({
+      await ctx.prisma.ticket.update({
         where: { id: input.ticketId },
         data: { staffNotes: input.notes },
       });
 
-      await convertTicketToTicketWithNames([ticket], ctx).then(async tickets => {
-        const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
+      const ably = new Ably.Rest(process.env.ABLY_SERVER_API_KEY!);
 
-        // Uses ticket inner page channel
-        for (const ticket of tickets) {
-          const channel = ably.channels.get(`ticket-${ticket.id}`);
-          await channel.publish('ticket-staffnote', ticket);
-        }
-        return tickets;
-      });
+      // Uses ticket inner page channel
+      const channel = ably.channels.get(`ticket-${input.ticketId}`);
+      await channel.publish('ticket-staffnote', undefined);
     }),
 
   getTicket: protectedProcedure

--- a/src/utils/hooks/useNotification.tsx
+++ b/src/utils/hooks/useNotification.tsx
@@ -11,6 +11,7 @@ const useNotification = () => {
     const notification = new Notification(message ?? 'New Office Hours Notification', {
       body,
       icon: '/favicon.ico',
+	  tag: '1',
       ...options,
     });
 


### PR DESCRIPTION
https://github.com/Berkeley-CS61B/simple-office-hours-queue/issues/63 mentions an issue where Resolve/Approve/Help all would crash with too many tickets. This is because of Ably's bandwidth limit. I realized that we actually don't need to send any payload in the Ably publishing because we end up invalidating the query on the client regardless. So this PR also includes a major refactor of `ticket.ts`.