### PR TITLE
Disable admin create button

### DIFF
--- a/src/components/admin/AdminList.tsx
+++ b/src/components/admin/AdminList.tsx
@@ -245,7 +245,15 @@ const AdminList = (props: AdminListProps) => {
                 </Tooltip>
               </Checkbox>
             </Flex>
-            <Button colorScheme="green" onClick={handleCreate} ml={3}>
+            <Button
+              colorScheme="green"
+              onClick={handleCreate}
+              ml={3}
+              disabled={
+                createText.length === 0 ||
+                (isAssignment && assignmentCategoryId === undefined)
+              }
+            >
               Create
             </Button>
           </Flex>


### PR DESCRIPTION
When the length of the location/assignment is 0, the create button should be disabled. It previously showed an error toast but it's more clear if users can't select it initially.